### PR TITLE
Focus code field if no #factor_selector, always submit on enter.

### DIFF
--- a/data/content-script.js
+++ b/data/content-script.js
@@ -17,15 +17,22 @@ self.port.on('init', function(prefs) {
     if (!document.querySelector('#extra-verification-challenge')) {
         return;
     }
+    if(document.querySelector('#factor_selector')) {
 
-    // fix overly long devices
-    for (let option of document.querySelectorAll('#factor_selector option')) {
-        option.textContent = option.textContent.replace(/ \S+DuoPushPhone\S+ /, ' Phone ');
+        // fix overly long devices
+        for (let option of document.querySelectorAll('#factor_selector option')) {
+            option.textContent = option.textContent.replace(/ \S+DuoPushPhone\S+ /, ' Phone ');
+        }
+
+        // focus the currently visible code field after factor selected
+        document.querySelector('#factor_selector').addEventListener('change', focus_code_field);
+        focus_code_field();
+
+    } else {
+
+        // focus the code field if there is no #factor_selector
+        focus_code_field();
     }
-
-    // focus the currently visible code field
-    document.querySelector('#factor_selector').addEventListener('change', focus_code_field);
-    focus_code_field();
 
     // pressing enter in the code field should submit
     for (let input of document.querySelectorAll('[id^=duo-verify-code-]')) {
@@ -39,3 +46,4 @@ self.port.on('init', function(prefs) {
         }
     }
 });
+


### PR DESCRIPTION
Coding a little blind, I hope I didn't break your use case. Should fix #1 

I only have one device for auth so I don't see #factor_selector and would like the code field to focus automatically.

Pressing enter in the code field should submit the form in both our situations.
