### PR TITLE
Re-focus code field after submit.

### DIFF
--- a/data/content-script.js
+++ b/data/content-script.js
@@ -2,6 +2,7 @@ function focus_code_field() {
     for (let input of document.querySelectorAll('[id^=duo-verify-code-]')) {
         if (input.offsetParent) {
             input.focus();
+            input.select();
             break;
         }
     }
@@ -31,6 +32,10 @@ self.port.on('init', function(prefs) {
     for (let input of document.querySelectorAll('[id^=duo-verify-code-]')) {
         input.addEventListener('keypress', on_code_keypressed);
     }
+
+    // put focus back on code field on submit in case of code error
+    document.querySelector('#verify_factor').addEventListener('click', focus_code_field);
+
 
     // check 'remember device' if required
     if (prefs.rememberDevice) {


### PR DESCRIPTION
If there's an error with the code we'll have to re-enter it, put the focus back on the code field when the form is submitted.
